### PR TITLE
Fix- hostName should end with .com in ssh config

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -23,7 +23,7 @@ if (program.generate) {
     let config = answers;
     config['host'] = `${config.hostingProvider}-${config.username}`;
     config['rsa_filename'] = `${config.hostingProvider}_${config.username}_id_rsa`;
-    config['hostName'] = `${config.hostingProvider}`;
+    config['hostName'] = `${config.hostingProvider}.com`;
 
     generateKeysAndConfig(config);
   });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "ssh-git",
-  "version": "0.0.2",
+  "version": "0.0.3",
   "description": "Node CLI used to generate and setup ssh keys for using multiple accounts github/gitlab/bitbucket accounts using ssh",
   "scripts": {},
   "keywords": [
@@ -15,10 +15,10 @@
   },
   "repository": {
     "type": "git",
-    "url": "https://github.com/punitda/ssh-key-and-config-generator.git"
+    "url": "https://github.com/punitda/ssh-git.git"
   },
   "bugs": {
-    "url": "https://github.com/punitda/ssh-key-and-config-generator/issues"
+    "url": "https://github.com/punitda/ssh-git/issues"
   },
   "engines": {
     "node": ">=6.0.0"


### PR DESCRIPTION
- HostName should end with `.com` in ssh config file for correct handling of ssh keys.
- Fixed repo and issue urls in package.json(They were pointing to older repo - `ssh-key-and-config-generator`)
- Version bump for HostName change.