### PR TITLE
Use default shell

### DIFF
--- a/lib/shellHelper.js
+++ b/lib/shellHelper.js
@@ -5,11 +5,10 @@ const chalk = require('chalk');
 
 const sshDir = path.join(os.homedir(), '.ssh');
 
-const execute = (command, shell, message, cb) => {
+const execute = (command, message, cb) => {
   console.log(chalk`{bold ${message}}`);
   let childProcess = exec(command, {
-    cwd: `${sshDir}`,
-    shell
+    cwd: `${sshDir}`
   });
 
   childProcess.on('exit', code => {
@@ -28,21 +27,17 @@ const execute = (command, shell, message, cb) => {
 };
 
 const runCommands = (commands, messages, cb) => {
-  let execNext = shell => {
-    execute(commands.shift(), shell, messages.shift(), err => {
+  let execNext = () => {
+    execute(commands.shift(), messages.shift(), err => {
       if (err) {
         cb(err);
       } else {
-        if (commands.length) execNext(shell);
+        if (commands.length) execNext();
         else cb(null);
       }
     });
   };
-  exec('echo $SHELL', (_error, stdout, _stderr) => {
-    const defaultShell = stdout.trim();
-    console.log(chalk`{bold Using default shell: ${defaultShell}}`);
-    execNext(defaultShell);
-  });
+  execNext();
 };
 
 module.exports = runCommands;

--- a/lib/shellHelper.js
+++ b/lib/shellHelper.js
@@ -5,14 +5,14 @@ const chalk = require('chalk');
 
 const sshDir = path.join(os.homedir(), '.ssh');
 
-const execute = (command, message, cb) => {
+const execute = (command, shell, message, cb) => {
   console.log(chalk`{bold ${message}}`);
   let childProcess = exec(command, {
     cwd: `${sshDir}`,
-    shell: '/bin/zsh'
+    shell
   });
 
-  childProcess.on('exit', function(code) {
+  childProcess.on('exit', code => {
     let err = null;
     if (code) {
       err = new Error(`command : ${command} exited with wrong status code ${code}`);
@@ -27,18 +27,22 @@ const execute = (command, message, cb) => {
   });
 };
 
-const runCommands = function(commands, messages, cb) {
-  let execNext = function() {
-    execute(commands.shift(), messages.shift(), function(err) {
+const runCommands = (commands, messages, cb) => {
+  let execNext = shell => {
+    execute(commands.shift(), shell, messages.shift(), err => {
       if (err) {
         cb(err);
       } else {
-        if (commands.length) execNext();
+        if (commands.length) execNext(shell);
         else cb(null);
       }
     });
   };
-  execNext();
+  exec('echo $SHELL', (_error, stdout, _stderr) => {
+    const defaultShell = stdout.trim();
+    console.log(chalk`{bold Using default shell: ${defaultShell}}`);
+    execNext(defaultShell);
+  });
 };
 
 module.exports = runCommands;


### PR DESCRIPTION
`exec()` uses system's default shell so no need to explicit pass shell like we're doing initially.
remove `shell` parameter passed to `exec()` function. It is required in case of `spawn()`.

More details : https://www.freecodecamp.org/news/node-js-child-processes-everything-you-need-to-know-e69498fe970a/