### PR TITLE
:bug: fix overwriting ssh key with same name

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -43,10 +43,10 @@ function generateKeysAndConfig(config) {
   ];
 
   const messages = [
-    `Generating ssh keys...`,
-    `Starting ssh-agent...`,
-    `Adding generated ssh keys to the OSX Keychain so that you don't have to remember passphrase of ssh keys when using them. Please enter the passphrase you just entered in the previous step to add it to keychain`,
-    `Copying the public key to the Clipboard...`
+    `> Generating ssh keys...`,
+    `> Starting ssh-agent...`,
+    `> Adding generated ssh keys to the OSX Keychain so that you don't have to remember passphrase of ssh keys when using them. Please enter the passphrase you just entered in the previous step to add it to keychain`,
+    `> Copying the public key to the Clipboard...`
   ];
 
   const sshConfig = `
@@ -61,10 +61,10 @@ Host ${config.host}
   runCommands(commands, messages, (err, _results) => {
     {
       if (err === null) {
-        log(chalk`{bold Adding IdentityFile to ssh config file}`);
+        log(chalk`{bold > Adding IdentityFile to ssh config file\n\n}`);
         fs.appendFileSync(sshConfigFileLocation, sshConfig);
         log(
-          chalk`{green.bold ssh key and config generated successfully 🎉  and Public key has been copied to your Clipboard. \n\n}`
+          chalk`{green.bold ssh key and config generated successfully 🎉  and public key has been copied to your Clipboard. \n\n}`
         );
         log(
           chalk`{blue.bold Few steps you need to follow next to start using this ssh key:\n1. Login into your ${
@@ -82,11 +82,7 @@ Host ${config.host}
             chalk.green.bold.underline(`${config.host}`)
         );
       } else {
-        log(
-          chalk`{red.bold Something went wrong when running command : ${
-            err.cmd
-          } \n ${err}}`
-        );
+        log(chalk`{red.bold ${err}}`);
       }
     }
   });

--- a/lib/shellHelper.js
+++ b/lib/shellHelper.js
@@ -1,28 +1,41 @@
 const os = require('os');
 const path = require('path');
-const exec = require('child_process').exec;
+const {spawn} = require('child_process');
 const chalk = require('chalk');
 
 const sshDir = path.join(os.homedir(), '.ssh');
 
 const execute = (command, message, cb) => {
   console.log(chalk`{bold ${message}}`);
-  let childProcess = exec(command, {
-    cwd: `${sshDir}`
+  const child_process = spawn(command, {
+    stdio: [process.stdin, 'pipe', 'pipe'],
+    cwd: `${sshDir}`,
+    shell: true
   });
 
-  childProcess.on('exit', code => {
+  child_process.stdout.on('data', data => {
+    console.log(`${data}`);
+  });
+
+  child_process.once('exit', code => {
     let err = null;
     if (code) {
-      err = new Error(`command : ${command} exited with wrong status code ${code}`);
+      if (command.includes('ssh-key'))
+        err = new Error(
+          'Cool! As instructed, not overwriting existing ssh-key and stopping the ssh-key generation process.'
+        );
+      else
+        err = new Error(
+          `Something went wrong when running command : ${command} exited with status code ${code}`
+        );
       err.code = code;
       err.cmd = command;
     }
     if (cb) cb(err);
   });
 
-  childProcess.stdout.on('data', data => {
-    console.log(`${data}`);
+  child_process.once('error', error => {
+    if (cb) cb(error);
   });
 };
 


### PR DESCRIPTION
 Decided to switch to `spawn` instead of using `exec` as in the case when generating ssh-keys using this CLI there is chance that user might have created ssh-key with same name previously using command line or some other tool. 
In such case, when the user is prompted by `ssh-keygen` command about whether to overwrite existing key or not we need our child_process running the command to take user input from the main process.
With existing code, it is not possible to do so using `exec` command. This is because `spawn()` command let us access the stdin, stdout and stderr of command while it is running. This might be possible using `exec()` but with current experience i don't think that is possible.

So, decided to use `spawn()` where in we pass arguments for `stdio` as `['process.stdin', 'pipe', 'pipe']`.
With these our main process has access to standard input and we can take in input from user when we face overwriting ssh key with same name thus letting user decide whether to overwrite ssh key or not whereas we continue using our child process's stdout and stderr for outputting results and error directly using `pipe`.


In addition to above changes, did some minor changes in output and error logging. 